### PR TITLE
Exibição de senha funcionando corretamente ao marcar a CheckBox_ShowPass

### DIFF
--- a/ERPGarcia/View/TelaInicial.Designer.cs
+++ b/ERPGarcia/View/TelaInicial.Designer.cs
@@ -32,7 +32,7 @@
             TxtBLogin = new TextBox();
             TxtBSenha = new TextBox();
             ButtonLogin = new Button();
-            CheckBox_ShowPass = new CheckBox();
+            CheckBoxShowPass = new CheckBox();
             SuspendLayout();
             // 
             // TxtBLogin
@@ -68,23 +68,23 @@
             ButtonLogin.UseVisualStyleBackColor = true;
             ButtonLogin.Click += ButtonLogin_Click;
             // 
-            // CheckBox_ShowPass
+            // CheckBoxShowPass
             // 
-            CheckBox_ShowPass.AutoSize = true;
-            CheckBox_ShowPass.Location = new Point(52, 192);
-            CheckBox_ShowPass.Name = "CheckBox_ShowPass";
-            CheckBox_ShowPass.Size = new Size(101, 19);
-            CheckBox_ShowPass.TabIndex = 3;
-            CheckBox_ShowPass.Text = "Mostrar senha";
-            CheckBox_ShowPass.UseVisualStyleBackColor = true;
-            CheckBox_ShowPass.CheckedChanged += CheckBox_ShowPass_CheckedChanged;
+            CheckBoxShowPass.AutoSize = true;
+            CheckBoxShowPass.Location = new Point(52, 192);
+            CheckBoxShowPass.Name = "CheckBoxShowPass";
+            CheckBoxShowPass.Size = new Size(101, 19);
+            CheckBoxShowPass.TabIndex = 3;
+            CheckBoxShowPass.Text = "Mostrar senha";
+            CheckBoxShowPass.UseVisualStyleBackColor = true;
+            CheckBoxShowPass.CheckedChanged += CheckBoxShowPass_CheckedChanged;
             // 
             // TelaInicial
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(468, 366);
-            Controls.Add(CheckBox_ShowPass);
+            Controls.Add(CheckBoxShowPass);
             Controls.Add(ButtonLogin);
             Controls.Add(TxtBSenha);
             Controls.Add(TxtBLogin);
@@ -101,6 +101,6 @@
         private TextBox TxtBLogin;
         private TextBox TxtBSenha;
         private Button ButtonLogin;
-        private CheckBox CheckBox_ShowPass;
+        private CheckBox CheckBoxShowPass;
     }
 }

--- a/ERPGarcia/View/TelaInicial.cs
+++ b/ERPGarcia/View/TelaInicial.cs
@@ -91,16 +91,12 @@ namespace ERPGarcia
             return true;
         }
 
-        private void CheckBox_ShowPass_CheckedChanged(object sender, EventArgs e)
+        private void CheckBoxShowPass_CheckedChanged(object sender, EventArgs e)
         {
-            if (CheckBox_ShowPass.Checked)
-            {
+            if (CheckBoxShowPass.Checked)
                 TxtBSenha.UseSystemPasswordChar = false;
-            }
             else
-            {
                 TxtBSenha.UseSystemPasswordChar = true;
-            }
         }
     }
 }


### PR DESCRIPTION
Para fazer o checkbox que exibe a senha, removi do form o "TxtBSenha.PasswordChar = '*';" para definir o bool "TxtBSenha.UseSystemPasswordChar" para true, o que acaba no mesmo resultado. Mas dessa forma, pude fazer um condicional para passar esse bool para false e exibir a senha ao usuário :)

Segue um curto video do funcionamento na descrição do PR